### PR TITLE
Properly check for string type with support for unicode

### DIFF
--- a/version.py
+++ b/version.py
@@ -49,7 +49,7 @@ class _Seq(_Comparable):
 
 
 def _try_int(s):
-    assert type(s) is str
+    assert isinstance(s, basestring)
     try:
         return int(s)
     except ValueError:


### PR DESCRIPTION
The assertion fails if a unicode string is provided.