### PR TITLE
Fix python3 setup with error izip_longest not found

### DIFF
--- a/version.py
+++ b/version.py
@@ -1,5 +1,11 @@
 import re
-from itertools import izip_longest
+try:
+    # Python 3
+    from itertools import zip_longest as izip_longest
+except ImportError:
+    # Python 2
+    from itertools import izip_longest
+
 
 
 class _Comparable(object):


### PR DESCRIPTION
I found the error when I run pip3 install version. Because the izip_longest is renamed to zip_longest in python3. 